### PR TITLE
Various Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A comprehensive media management card and integration for Home Assistant that br
   - Coming Soon: Jellyfin and Emby support
 
 - **Media Management**
-  - Sonarr: View upcoming TV shows and episodes
-  - Radarr: Track upcoming movie releases
-
+  - Sonarr: View upcoming TV shows and episodes (With support for Cloudflare Access authentication via Cloudflare Service Token)
+  - Radarr: Track upcoming movie releases (With support for Cloudflare Access authentication via Cloudflare Service Token)
+  
 - **Media Discovery**
   - Trakt: Browse popular TV shows and movies
   - TMDB: Explore trending content (configurable for TV, movies, or both)
@@ -54,7 +54,7 @@ Add one or more of the following sensors to your `configuration.yaml`:
 sensor:
   - platform: mediarr
     plex:  # Optional
-      host: localhost
+      host: http://localhost
       port: 32400
       token: your_plex_token
       max_items: 10
@@ -64,11 +64,15 @@ sensor:
       api_key: your_sonarr_api_key
       max_items: 10
       days_to_check: 60
+      cf_client_id: xxx #Cloudflare Access Service Token Client ID
+      cf_client_secret: xxx #Cloudflare Access Service Token Client Secret
     
     radarr:  # Optional
       url: http://localhost:7878
       api_key: your_radarr_api_key
       max_items: 10
+      cf_client_id: xxx #Cloudflare Access Service Token Client ID
+      cf_client_secret: xxx #Cloudflare Access Service Token Client Secret
 
     trakt:  # Optional
       client_id: "your_client_id"

--- a/custom_components/mediarr/manager/radarr.py
+++ b/custom_components/mediarr/manager/radarr.py
@@ -76,12 +76,21 @@ class RadarrMediarrSensor(MediarrSensor):
                             if release_dates:
                                 release_dates.sort(key=lambda x: x[1])
                                 release_type, release_date = release_dates[0]
-
+                                fanart_url = None
+                                for f_image in movie["images"]:
+                                    if f_image["coverType"] == "fanart":
+                                        fanart_url = f_image["remoteUrl"]
+                                        break  # Stop searching after finding the first match
+                                poster_url = None
+                                for p_image in movie["images"]:
+                                    if p_image["coverType"] == "poster":
+                                        poster_url = p_image["remoteUrl"]
+                                        break  # Stop searching after finding the first match
                                 movie_data = {
                                     "title": movie["title"],
                                     "year": movie["year"],
-                                    "poster": f"{self._url}/api/v3/mediacover/{movie['id']}/poster.jpg?apikey={self._api_key}",
-                                    "fanart": f"{self._url}/api/v3/mediacover/{movie['id']}/fanart.jpg?apikey={self._api_key}",
+                                    "poster": poster_url,
+                                    "fanart": fanart_url,
                                     "overview": movie["overview"],
                                     "runtime": movie.get("runtime", 0),
                                     "monitored": True,

--- a/custom_components/mediarr/manager/radarr.py
+++ b/custom_components/mediarr/manager/radarr.py
@@ -10,7 +10,7 @@ from ..common.sensor import MediarrSensor
 _LOGGER = logging.getLogger(__name__)
 
 class RadarrMediarrSensor(MediarrSensor):
-    def __init__(self, session, api_key, url, max_items):
+    def __init__(self, session, api_key, url, max_items, cf_client_id, cf_client_secret):
         """Initialize the sensor."""
         super().__init__()
         self._session = session
@@ -18,6 +18,8 @@ class RadarrMediarrSensor(MediarrSensor):
         self._url = url.rstrip('/')
         self._max_items = max_items
         self._name = "Radarr Mediarr"
+        self._cf_client_id = cf_client_id
+        self._cf_client_secret = cf_client_secret
 
     @property
     def name(self):
@@ -32,7 +34,11 @@ class RadarrMediarrSensor(MediarrSensor):
     async def async_update(self):
         """Update the sensor."""
         try:
-            headers = {'X-Api-Key': self._api_key}
+            headers = {
+                'X-Api-Key': self._api_key,
+                "CF-Access-Client-Id": self._cf_client_id,
+                "CF-Access-Client-Secret": self._cf_client_secret,
+                }
             now = datetime.now().astimezone()
 
             async with async_timeout.timeout(10):

--- a/custom_components/mediarr/manager/sonarr.py
+++ b/custom_components/mediarr/manager/sonarr.py
@@ -81,7 +81,16 @@ class SonarrMediarrSensor(MediarrSensor):
                             except ValueError as e:
                                 _LOGGER.warning("Error parsing date: %s", e)
                                 continue
-
+                            fanart_url = None
+                            for f_image in series["images"]:
+                                if f_image["coverType"] == "fanart":
+                                    fanart_url = f_image["remoteUrl"]
+                                    break  # Stop searching after finding the first match
+                            poster_url = None
+                            for p_image in series["images"]:
+                                if p_image["coverType"] == "poster":
+                                    poster_url = p_image["remoteUrl"]
+                                    break  # Stop searching after finding the first match
                             series_id = series['id']
                             show_data = {
                                 'title': series['title'],
@@ -93,8 +102,8 @@ class SonarrMediarrSensor(MediarrSensor):
                                 }],
                                 'runtime': series.get('runtime', 0),
                                 'network': series.get('network', ''),
-                                'poster': f"{self._url}/api/v3/mediacover/{series['id']}/poster.jpg?apikey={self._api_key}",
-                                'fanart': f"{self._url}/api/v3/mediacover/{series['id']}/fanart.jpg?apikey={self._api_key}",
+                                'poster': poster_url,
+                                'fanart': fanart_url,
                                 'airdate': episode['airDate'],
                                 'monitored': True,
                                 'next_episode': {

--- a/custom_components/mediarr/manager/sonarr.py
+++ b/custom_components/mediarr/manager/sonarr.py
@@ -11,7 +11,7 @@ from ..common.sensor import MediarrSensor
 _LOGGER = logging.getLogger(__name__)
 
 class SonarrMediarrSensor(MediarrSensor):
-    def __init__(self, session, api_key, url, max_items, days_to_check):
+    def __init__(self, session, api_key, url, max_items, days_to_check, cf_client_id, cf_client_secret):
         """Initialize the sensor."""
         super().__init__()
         self._session = session
@@ -20,6 +20,8 @@ class SonarrMediarrSensor(MediarrSensor):
         self._max_items = max_items
         self._days_to_check = days_to_check
         self._name = "Sonarr Mediarr"
+        self._cf_client_id = cf_client_id
+        self._cf_client_secret = cf_client_secret
 
     @property
     def name(self):
@@ -41,7 +43,11 @@ class SonarrMediarrSensor(MediarrSensor):
     async def async_update(self):
         """Update the sensor."""
         try:
-            headers = {'X-Api-Key': self._api_key}
+            headers = {
+                'X-Api-Key': self._api_key,
+                "CF-Access-Client-Id": self._cf_client_id,
+                "CF-Access-Client-Secret": self._cf_client_secret,
+                }
             now = datetime.now(ZoneInfo('UTC'))
             params = {
                 'start': now.strftime('%Y-%m-%d'),

--- a/custom_components/mediarr/sensor.py
+++ b/custom_components/mediarr/sensor.py
@@ -30,7 +30,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             config["sonarr"]["api_key"],
             config["sonarr"]["url"],
             config["sonarr"].get("max_items", DEFAULT_MAX_ITEMS),
-            config["sonarr"].get("days_to_check", DEFAULT_DAYS)
+            config["sonarr"].get("days_to_check", DEFAULT_DAYS),
+            config["sonarr"]["cf_client_id"],
+            config["sonarr"]["cf_client_secret"]
         ))
 
     if "radarr" in config:
@@ -39,7 +41,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             session,
             config["radarr"]["api_key"],
             config["radarr"]["url"],
-            config["radarr"].get("max_items", DEFAULT_MAX_ITEMS)
+            config["radarr"].get("max_items", DEFAULT_MAX_ITEMS),
+            config["radarr"]["cf_client_id"],
+            config["radarr"]["cf_client_secret"]
         ))
 
     # Discovery Sensors

--- a/custom_components/mediarr/server/plex.py
+++ b/custom_components/mediarr/server/plex.py
@@ -12,7 +12,7 @@ from ..common.sensor import MediarrSensor
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_HOST = 'localhost'
+DEFAULT_HOST = 'http://localhost'
 DEFAULT_PORT = 32400
 
 PLEX_SCHEMA = {
@@ -46,7 +46,7 @@ class PlexMediarrSensor(MediarrSensor):
     async def create_sensors(cls, hass, config):
         """Create Plex sensor entities."""
         try:
-            base_url = f"http://{config[CONF_HOST]}:{config[CONF_PORT]}"
+            base_url = f"{config[CONF_HOST]}:{config[CONF_PORT]}"
             server = await hass.async_add_executor_job(
                 lambda: PlexServer(base_url, config[CONF_TOKEN])
             )


### PR DESCRIPTION
1. Added Support for Cloudflare Access Authentication for radarr and sonarr
	You can specify cf_client_id and cf_client_secret for radarr and sonarr which will then be passes on as custom http headers for authentication.
2. The Plex url was hardcoded as http.
	So now, instead of specifying plex hostname, you have to specify full url with http or https. So external plex auth is possible now.
3. Since custom http headers can't be specified for "img src" tags in html, so posters were broken in case of cloudflare authentication when accessing externally. So i replaced those posters url with tmdb and tvdb ones. So now, posters work even in case of cloudflare authentication.
4. Updated readme to reflect these changes.